### PR TITLE
Fix Registry.yml: quote Julia version string

### DIFF
--- a/.github/workflows/Registry.yml
+++ b/.github/workflows/Registry.yml
@@ -21,7 +21,7 @@ jobs:
           registry: bhftbootcamp/Green
       - uses: julia-actions/setup-julia@v2
         with:
-          version: 1.10
+          version: '1.10'
       - uses: julia-actions/cache@v2
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
- YAML parses unquoted `1.10` as float `1.1`, causing `setup-julia` to install Julia 1.1
- `Pkg.develop(url=...)` doesn't exist in Julia 1.1, breaking the registry update workflow
- Fix: quote the version string `'1.10'`