### PR TITLE
Use Julia 1.9 in Registry.yml

### DIFF
--- a/.github/workflows/Registry.yml
+++ b/.github/workflows/Registry.yml
@@ -21,7 +21,7 @@ jobs:
           registry: bhftbootcamp/Green
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: 1.9
       - uses: julia-actions/cache@v2
       - name: Configure Git
         run: |


### PR DESCRIPTION
Downgrade from 1.10 to 1.9 — registry workflow doesn't need latest Julia. Avoids YAML float parsing issue entirely.